### PR TITLE
Use go 1.16 instead of 1.16-rc1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.16rc1"]
+        go: ["1.16"]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.16.0-rc1", "tip"]
+        go: ["1.16", "tip"]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/Dockerfilex
+++ b/Dockerfilex
@@ -1,6 +1,6 @@
 # vim: set ft=dockerfile:
 
-ARG GO_VERSION=1.16rc1
+ARG GO_VERSION=1.16
 
 # Base image
 FROM --platform=$BUILDPLATFORM golang:$GO_VERSION AS go


### PR DESCRIPTION
Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>